### PR TITLE
Update usb.c

### DIFF
--- a/common/src/usb.c
+++ b/common/src/usb.c
@@ -775,7 +775,7 @@ static const USBControlStateEntry usb_control_fsm[] = {
  *
  * token: Token type that has been completed and triggered the call to this function
  */
-static void usb_handle_endp0(USBToken token)
+static __attribute__((optimize("O0"))) void usb_handle_endp0(USBToken token)
 {
     static USBControlState state = USB_ST_SETUP;
 


### PR DESCRIPTION
Hello Kevin :

If we try to optimize the code the USB will not be recognized, except -O0. 

I find that we need to keep the usb_handle_endp0 function in usb.c to O0 to avoid it being optimized and then we can optimize the others.

BR CCTSAO